### PR TITLE
add package model for morph-browser

### DIFF
--- a/src/plugin/tweaktool/packagesmodel.cpp
+++ b/src/plugin/tweaktool/packagesmodel.cpp
@@ -156,6 +156,7 @@ void PackagesModel::appendSystemApps()
     systemApps << QString(DESKTOP_FILES_FOLDER_SYSTEM) + "/messaging-app.desktop";
     systemApps << QString(DESKTOP_FILES_FOLDER_SYSTEM) + "/ubuntu-system-settings.desktop";
     systemApps << QString(DESKTOP_FILES_FOLDER_SYSTEM) + "/webbrowser-app.desktop";
+    systemApps << QString(DESKTOP_FILES_FOLDER_SYSTEM) + "/morph-browser.desktop";
 
     Q_FOREACH(const QString &path, systemApps) {
         if (QFileInfo::exists(path)) {

--- a/ut-tweak-tool/packagesmodel.cpp
+++ b/ut-tweak-tool/packagesmodel.cpp
@@ -156,6 +156,7 @@ void PackagesModel::appendSystemApps()
     systemApps << QString(DESKTOP_FILES_FOLDER_SYSTEM) + "/messaging-app.desktop";
     systemApps << QString(DESKTOP_FILES_FOLDER_SYSTEM) + "/ubuntu-system-settings.desktop";
     systemApps << QString(DESKTOP_FILES_FOLDER_SYSTEM) + "/webbrowser-app.desktop";
+    systemApps << QString(DESKTOP_FILES_FOLDER_SYSTEM) + "/morph-browser.desktop";
 
     Q_FOREACH(const QString &path, systemApps) {
         if (QFileInfo::exists(path)) {


### PR DESCRIPTION
The new renamed browser in 16.04 is morph-browser, this adds it to the package model so users can view and prevent app suspension.